### PR TITLE
Add automatic GitHub releases generation.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ colorama = "*"
 gitpython = "^3.0"
 graphviz = "^0.13.0"
 petname = "^2.6"
-pygithub = "^1.47"
+pygithub = { git = "https://github.com/WojciechBarczynski/PyGithub", branch = "add_generate_release_notes" }
 python-dotenv = "^0.10.5"
 pyyaml = "^5.3"
 semver = "^2.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,10 @@ colorama = "*"
 gitpython = "^3.0"
 graphviz = "^0.13.0"
 petname = "^2.6"
+# TODO we should use the official PyGithub library instead of the fork
+#  but since it may take quite a lot of time (probably a few months)
+#  to merge PR adding generate_release_notes, we can use the forked version.
+#  After merging and releasing that PR we should change the dependency.
 pygithub = { git = "https://github.com/WojciechBarczynski/PyGithub", branch = "add_generate_release_notes" }
 python-dotenv = "^0.10.5"
 pyyaml = "^5.3"

--- a/sebex/release/executor/__init__.py
+++ b/sebex/release/executor/__init__.py
@@ -3,6 +3,7 @@ from typing import List, Type
 from sebex.log import operation, logcontext
 from sebex.release.executor.cleanup import Cleanup
 from sebex.release.executor.close_release_branch import CloseReleaseBranch
+from sebex.release.executor.create_gh_release import CreateGHRelease
 from sebex.release.executor.merge_pull_request import MergePullRequest
 from sebex.release.executor.open_pull_request import OpenPullRequest
 from sebex.release.executor.open_release_branch import OpenReleaseBranch
@@ -15,6 +16,7 @@ _ALL_TASK_TYPES: List[Type[Task]] = [
     OpenPullRequest,
     MergePullRequest,
     CloseReleaseBranch,
+    CreateGHRelease,
     PublishPackage,
     Cleanup,
 ]

--- a/sebex/release/executor/__init__.py
+++ b/sebex/release/executor/__init__.py
@@ -3,7 +3,7 @@ from typing import List, Type
 from sebex.log import operation, logcontext
 from sebex.release.executor.cleanup import Cleanup
 from sebex.release.executor.close_release_branch import CloseReleaseBranch
-from sebex.release.executor.create_gh_release import CreateGHRelease
+from sebex.release.executor.create_github_release import CreateGithubRelease
 from sebex.release.executor.merge_pull_request import MergePullRequest
 from sebex.release.executor.open_pull_request import OpenPullRequest
 from sebex.release.executor.open_release_branch import OpenReleaseBranch
@@ -16,7 +16,7 @@ _ALL_TASK_TYPES: List[Type[Task]] = [
     OpenPullRequest,
     MergePullRequest,
     CloseReleaseBranch,
-    CreateGHRelease,
+    CreateGithubRelease,
     PublishPackage,
     Cleanup,
 ]

--- a/sebex/release/executor/create_gh_release.py
+++ b/sebex/release/executor/create_gh_release.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+
+from github import Repository as GithubRepository
+from github.PullRequest import PullRequest
+
+from sebex.config.manifest import Manifest
+from sebex.release.executor.types import Task, Action
+from sebex.release.git import release_tag_name
+from sebex.release.state import ReleaseStage, ReleaseState
+
+
+@dataclass
+class CreateGHRelease(Task):
+    @classmethod
+    def stage(cls) -> ReleaseStage:
+        return ReleaseStage.CREATE_GH_RELEASE
+
+    def run(self, release: ReleaseState) -> Action:
+        tag = release_tag_name(self.project)
+        vsc = self.project.project.repo.vcs
+
+        # TODO after updating PyGithub lib we should handle creating automatic
+        # release notes generation (just sending another bool in POST)
+        vsc.create_github_release(tag=tag, message=tag)
+
+        return Action.PROCEED

--- a/sebex/release/executor/create_github_release.py
+++ b/sebex/release/executor/create_github_release.py
@@ -17,8 +17,8 @@ class CreateGithubRelease(Task):
 
     def run(self, release: ReleaseState) -> Action:
         tag = release_tag_name(self.project)
-        vsc = self.project.project.repo.vcs
+        vcs = self.project.project.repo.vcs
 
-        vsc.create_github_release(tag=tag, message=tag)
+        vcs.create_github_release(tag=tag, message=tag)
 
         return Action.PROCEED

--- a/sebex/release/executor/create_github_release.py
+++ b/sebex/release/executor/create_github_release.py
@@ -19,8 +19,6 @@ class CreateGithubRelease(Task):
         tag = release_tag_name(self.project)
         vsc = self.project.project.repo.vcs
 
-        # TODO after updating PyGithub lib we should handle creating automatic
-        # release notes generation (just sending another bool in POST)
         vsc.create_github_release(tag=tag, message=tag)
 
         return Action.PROCEED

--- a/sebex/release/executor/create_github_release.py
+++ b/sebex/release/executor/create_github_release.py
@@ -10,10 +10,10 @@ from sebex.release.state import ReleaseStage, ReleaseState
 
 
 @dataclass
-class CreateGHRelease(Task):
+class CreateGithubRelease(Task):
     @classmethod
     def stage(cls) -> ReleaseStage:
-        return ReleaseStage.CREATE_GH_RELEASE
+        return ReleaseStage.CREATE_GITHUB_RELEASE
 
     def run(self, release: ReleaseState) -> Action:
         tag = release_tag_name(self.project)

--- a/sebex/release/state.py
+++ b/sebex/release/state.py
@@ -26,7 +26,7 @@ class ReleaseStage(Enum):
     PULL_REQUEST_OPENED = 'pull_request_opened'
     PULL_REQUEST_MERGED = 'pull_request_merged'
     BRANCH_CLOSED = 'branch_closed'
-    CREATE_GH_RELEASE = 'create_gh_release'
+    CREATE_GITHUB_RELEASE = 'create_github_release'
     PUBLISHED = 'published'
     DONE = 'done'
 

--- a/sebex/release/state.py
+++ b/sebex/release/state.py
@@ -26,6 +26,7 @@ class ReleaseStage(Enum):
     PULL_REQUEST_OPENED = 'pull_request_opened'
     PULL_REQUEST_MERGED = 'pull_request_merged'
     BRANCH_CLOSED = 'branch_closed'
+    CREATE_GH_RELEASE = 'create_gh_release'
     PUBLISHED = 'published'
     DONE = 'done'
 

--- a/sebex/vcs.py
+++ b/sebex/vcs.py
@@ -100,9 +100,11 @@ class Vcs:
         self.git.create_tag(tag, message=message)
 
     def create_github_release(self, tag: str, message: str):
-        # TODO after updating PyGithub lib we should handle creating automatic
-        # release notes generation (just sending another bool in POST)
-        self.github.create_git_release(tag=tag, name=tag, message=message)
+        # TODO we should use the official PyGithub library instead of the fork
+        # but since it may take quite a lot of time (probably a few months)
+        # to merge PR by adding generate_release_notes we can use the forked version.
+        # After merging and releasing that PR we should change the dependency.
+        self.github.create_git_release(tag=tag, name=tag, message=message, generate_release_notes=True)
 
     def checkout(self, branch: str, ensure_clean: bool = True, delete_existing: bool = False):
         with operation(f'Checking out branch {branch}'):

--- a/sebex/vcs.py
+++ b/sebex/vcs.py
@@ -100,10 +100,6 @@ class Vcs:
         self.git.create_tag(tag, message=message)
 
     def create_github_release(self, tag: str, message: str):
-        # TODO we should use the official PyGithub library instead of the fork
-        #  but since it may take quite a lot of time (probably a few months)
-        #  to merge PR adding generate_release_notes we can use the forked version.
-        #  After merging and releasing that PR we should change the dependency.
         self.github.create_git_release(
             tag=tag, name=tag, message=message, generate_release_notes=True)
 

--- a/sebex/vcs.py
+++ b/sebex/vcs.py
@@ -102,9 +102,10 @@ class Vcs:
     def create_github_release(self, tag: str, message: str):
         # TODO we should use the official PyGithub library instead of the fork
         # but since it may take quite a lot of time (probably a few months)
-        # to merge PR by adding generate_release_notes we can use the forked version.
+        # to merge PR adding generate_release_notes we can use the forked version.
         # After merging and releasing that PR we should change the dependency.
-        self.github.create_git_release(tag=tag, name=tag, message=message, generate_release_notes=True)
+        self.github.create_git_release(
+            tag=tag, name=tag, message=message, generate_release_notes=True)
 
     def checkout(self, branch: str, ensure_clean: bool = True, delete_existing: bool = False):
         with operation(f'Checking out branch {branch}'):

--- a/sebex/vcs.py
+++ b/sebex/vcs.py
@@ -101,9 +101,9 @@ class Vcs:
 
     def create_github_release(self, tag: str, message: str):
         # TODO we should use the official PyGithub library instead of the fork
-        # but since it may take quite a lot of time (probably a few months)
-        # to merge PR adding generate_release_notes we can use the forked version.
-        # After merging and releasing that PR we should change the dependency.
+        #  but since it may take quite a lot of time (probably a few months)
+        #  to merge PR adding generate_release_notes we can use the forked version.
+        #  After merging and releasing that PR we should change the dependency.
         self.github.create_git_release(
             tag=tag, name=tag, message=message, generate_release_notes=True)
 

--- a/sebex/vcs.py
+++ b/sebex/vcs.py
@@ -14,7 +14,8 @@ from sebex.config.manifest import RepositoryHandle, Manifest
 from sebex.context import Context
 from sebex.log import log, operation, fatal, warn
 
-_GITHUB_SSH_URL = re.compile(r'git@github\.com:(?P<full>(?P<org>[^/]+)/(?P<repo>.+))\.git/?')
+_GITHUB_SSH_URL = re.compile(
+    r'git@github\.com:(?P<full>(?P<org>[^/]+)/(?P<repo>.+))\.git/?')
 _PR_MARKETING = r'''
 
 <sup>proudly automated with <a href="https://github.com/membraneframework/sebex">Sebex</a></sup>
@@ -88,7 +89,8 @@ class Vcs:
         log('Commit:', click.style(base_message, fg='magenta'))
 
         if files:
-            self.git.git.add('--', [p.relative_to(self.location) for p in files])
+            self.git.git.add(
+                '--', [p.relative_to(self.location) for p in files])
         else:
             self.git.git.add('.')
 
@@ -97,11 +99,17 @@ class Vcs:
     def tag(self, tag: str, message=None):
         self.git.create_tag(tag, message=message)
 
+    def create_github_release(self, tag: str, message: str):
+        # TODO after updating PyGithub lib we should handle creating automatic
+        # release notes generation (just sending another bool in POST)
+        self.github.create_git_release(tag=tag, name=tag, message=message)
+
     def checkout(self, branch: str, ensure_clean: bool = True, delete_existing: bool = False):
         with operation(f'Checking out branch {branch}'):
             # Clean existing (remote) branch if it exists
             if delete_existing and self.branch_exists(branch):
-                head: Head = next(h for h in self.git.heads if h.name == branch)
+                head: Head = next(
+                    h for h in self.git.heads if h.name == branch)
                 if head.tracking_branch() is not None:
                     fatal(f'Branch {branch} is already created and',
                           f'it tracks a remote branch {head.tracking_branch()}.',
@@ -187,7 +195,8 @@ class Vcs:
         body = body + _PR_MARKETING
         body = body.strip()
 
-        pr = self.github.create_pull(title=title, head=branch, base=base, body=body)
+        pr = self.github.create_pull(
+            title=title, head=branch, base=base, body=body)
 
         log('Pull request opened:', pr.html_url)
         return True


### PR DESCRIPTION
This PR adds automatic GitHub releases with release notes generation. Due to the lack of official PyGithub support for generating release notes, I've created a PR to the PyGithub library to support this feature, but since merging it might take some time (there are a lot of open PRs, merging it and releasing it in new PyGithub version will probably take a few months) I temporarily changed dependency to my forked version of this library with updated `create_git_release` function. 

I tested it on simple test organization with 10 repositories and it seems to be working correctly.

1. [Jira issue](https://membraneframework.atlassian.net/browse/MS-97)  
2. [PyGithub `create_git_release` documentation](https://pygithub.readthedocs.io/en/latest/github_objects/Repository.html?highlight=create_git_release#github.Repository.Repository.create_git_release) 
3. [Github create release documentation](https://docs.github.com/en/rest/releases/releases#create-a-release)
4. [PyGithub PR with `generate_release_notes` feature](https://github.com/PyGithub/PyGithub/pull/2417)